### PR TITLE
Start of implementing INSFileProviderReplicatedExtension correctly

### DIFF
--- a/MyFileProviderExtension/FileProviderDriver.cs
+++ b/MyFileProviderExtension/FileProviderDriver.cs
@@ -2,9 +2,46 @@
 using FileProvider;
 using Foundation;
 using ObjCRuntime;
+using UniformTypeIdentifiers;
 
 namespace MyFileProviderExtension
 {
+    public class FileProviderItem : NSObject, INSFileProviderItem
+    {
+        public string Identifier;
+        public FileProviderItem (string identifier)
+        {
+            Identifier = identifier;
+        }
+
+
+        string INSFileProviderItem.Identifier => Identifier;
+        string INSFileProviderItem.ParentIdentifier => NSFileProviderItemIdentifier.RootContainer;
+        string INSFileProviderItem.Filename => Identifier;
+        string INSFileProviderItem.TypeIdentifier => Identifier == NSFileProviderItemIdentifier.RootContainer ? UTTypes.Folder.ToString() : UTTypes.PlainText.ToString();
+    }
+
+    public class FileProviderEnumerator : NSObject, INSFileProviderEnumerator
+    {
+        string ContainerItemIdentifier;
+        public FileProviderEnumerator (string containerItemIdentifier)
+        {
+            ContainerItemIdentifier = containerItemIdentifier;
+        }
+
+
+        void INSFileProviderEnumerator.EnumerateItems(INSFileProviderEnumerationObserver observer, NSData startPage)
+        {
+            observer.DidEnumerateItems(new INSFileProviderItem[] { });
+            observer.FinishEnumerating((NSData)null);
+        }
+
+        void INSFileProviderEnumerator.Invalidate()
+        {
+        }
+    }
+
+
     [Register("FileProviderDriver")]
     public class FileProviderDriver: NSExtensionRequestHandling, INSFileProviderReplicatedExtension
     {
@@ -20,31 +57,33 @@ namespace MyFileProviderExtension
 
         public NSProgress CreateItem(INSFileProviderItem itemTemplate, NSFileProviderItemFields fields, NSUrl url, NSFileProviderCreateItemOptions options, NSFileProviderRequest request, NSFileProviderCreateOrModifyItemCompletionHandler completionHandler)
         {
-            return null;
+            completionHandler(itemTemplate, fields, false, null);
+            return new NSProgress ();
         }
 
         public NSProgress DeleteItem(string identifier, NSFileProviderItemVersion version, NSFileProviderDeleteItemOptions options, NSFileProviderRequest request, Action<NSError> completionHandler)
         {
-            return null;
+            completionHandler(new NSError(NSError.CocoaErrorDomain, 3328));
+            return new NSProgress();
         }
 
 
         public NSProgress FetchContents(string itemIdentifier, NSFileProviderItemVersion requestedVersion, NSFileProviderRequest request, NSFileProviderFetchContentsCompletionHandler completionHandler)
         {
-            return null;
+            completionHandler(null, null, new NSError(NSError.CocoaErrorDomain, 3328));
+            return new NSProgress();
         }
 
         public INSFileProviderEnumerator GetEnumerator(string containerItemIdentifier, NSFileProviderRequest request, out NSError error)
         {
-            error = NSError.FromDomain(new NSString("NSFileProviderErrorDomain"),
-                (int)NSFileProviderError.NotAuthenticated, null);
-
-            return null;
+            error = null;
+            return new FileProviderEnumerator(containerItemIdentifier);
         }
 
         public NSProgress GetItem(string identifier, NSFileProviderRequest request, Action<INSFileProviderItem, NSError> completionHandler)
         {
-            return null;
+            completionHandler(new FileProviderItem(identifier), null);
+            return new NSProgress();
         }
 
         public void Invalidate()


### PR DESCRIPTION
In investigating the [associated issue](https://github.com/xamarin/xamarin-macios/issues/15493) I found that `INSFileProviderReplicatedExtension` was not implemented correctly, which was causing the extension to misbehave.

In general with Apple APIs those that pass a completion handler like `NSFileProviderFetchContentsCompletionHandler completionHandler` it is a error to not invoke the handler when you are done using it. In none of the stubbed out code was this being done, which made the plugin interface assume that there was some internal error.

The code here was ported from [this swift sample](https://github.com/peterthomashorn/macosfileproviderexample) written by peterthomashorn. 

With this, we get a different error, but I have not investigated it further once it was obvious this was a coding error and not necessarily a Xamarin.Mac bug. Consider reviewing that sample and the associated API documentation, stub out the interfaces correctly, and things will likely work. 